### PR TITLE
Fix bound constraint on hindent version

### DIFF
--- a/hfmt.cabal
+++ b/hfmt.cabal
@@ -34,7 +34,7 @@ library
                      , exceptions
                      , filepath
                      , haskell-src-exts
-                     , hindent >= 5.0.0
+                     , hindent >= 5.2.3
                      , hlint >= 1.9
                      , HUnit
                      , path


### PR DESCRIPTION
Version 5.2.3 of hindent contains a breaking change to the `reformat`
function that we depend on in the current code.

Change in hindent: https://github.com/commercialhaskell/hindent/commit/b14e690af82e48fee6b3fd596bc96d4c1c31ea04

Will make version incompatibilities like #15 more obvious.