### PR TITLE
Implement PrintSources action for Actions.act

### DIFF
--- a/app/Actions.hs
+++ b/app/Actions.hs
@@ -21,7 +21,7 @@ act options r@(Reformat input source result) = act' (optAction options)
     act' PrintDiffs =
       when wasReformatted (printDiff input source result) >> return r
     act' PrintSources = do
-      when wasReformatted (writeSource InputFromStdIn (reformattedSource result))
+      when wasReformatted (printSource $ reformattedSource result)
       return (Reformat input (reformattedSource result) result)
     act' PrintFilePaths = when wasReformatted (print input) >> return r
     act' WriteSources = do
@@ -49,6 +49,9 @@ showDiff (HaskellSource a) (HaskellSource b) = render (toDoc diff)
     toDoc = prettyContextDiff (text "Original") (text "Reformatted") text
     diff = getContextDiff linesOfContext (lines a) (lines b)
     linesOfContext = 1
+
+printSource :: HaskellSource -> IO ()
+printSource (HaskellSource source) = putStr source
 
 writeSource :: InputFile -> HaskellSource -> IO ()
 writeSource (InputFilePath path) (HaskellSource source) = writeFile path source

--- a/app/Actions.hs
+++ b/app/Actions.hs
@@ -20,7 +20,9 @@ act options r@(Reformat input source result) = act' (optAction options)
   where
     act' PrintDiffs =
       when wasReformatted (printDiff input source result) >> return r
-    act' PrintSources = undefined
+    act' PrintSources = do
+      when wasReformatted (writeSource InputFromStdIn (reformattedSource result))
+      return (Reformat input (reformattedSource result) result)
     act' PrintFilePaths = when wasReformatted (print input) >> return r
     act' WriteSources = do
       when wasReformatted (writeSource input (reformattedSource result))


### PR DESCRIPTION
This hopes to resolve issue #17.

I basically copied what WriteSources was doing after trying to grok the desired behaviour for about an hour. This actually allows `:Neoformat hfmt` to apply it's reformatted changes.

However, I'm relatively certain (due to the code duplication) that I'm doing something wrong here. It would be ideal to know the distinction between PrintSources and WriteSources. My change basically does `writeSource` but forcing the `input` to always be `InputFromStdIn` so that we'll print the passed result.

I'm assuming the ideal implementation should look something like this, instead:

`Actions.hs`

```haskell
act' PrintSources = do 
  when wasReformatted (printSources (reformattedSource result))
  return (Reformat input (reformattedSource result) result)

<snip>

printSources :: HaskellSource -> IO ()
printSources (HaskellSource source) = putStr source
```