### PR TITLE
Exit code semantics

### DIFF
--- a/app/Actions.hs
+++ b/app/Actions.hs
@@ -28,7 +28,7 @@ printDiff (SourceFilePath path) source reformatted = do
   putStrLn (path ++ ":")
   mapM_ (putStr . show) (suggestions reformatted)
   putStr (showDiff source (reformattedSource reformatted))
-printDiff SourceFromStdIn source reformatted = do
+printDiff StdinSource source reformatted = do
   mapM_ (putStr . show) (suggestions reformatted)
   putStr (showDiff source (reformattedSource reformatted))
 
@@ -38,4 +38,4 @@ printSource (HaskellSource _ source) = putStr source
 writeSource :: SourceFile -> HaskellSource -> IO ()
 writeSource (SourceFilePath path) (HaskellSource _ source) =
   writeFile path source
-writeSource SourceFromStdIn (HaskellSource _ source) = putStr source
+writeSource StdinSource (HaskellSource _ source) = putStr source

--- a/app/Actions.hs
+++ b/app/Actions.hs
@@ -4,46 +4,38 @@ module Actions
 
 import Language.Haskell.Format
 import Language.Haskell.Format.Utilities
-import OptionsParser
+import Options
 import Types
 
 import Control.Monad
 
-act :: Options -> ReformatResult -> IO ReformatResult
-act options r@(InvalidReformat input errorString) = do
-  putStrLn ("Error reformatting " ++ show input ++ ": " ++ errorString)
-  return r
-act options r@(Reformat input source result) = act' (optAction options)
+act :: Options -> Formatted -> IO Formatted
+act options r@(Formatted input source result) = act' (optAction options)
   where
     act' PrintDiffs =
-      when wasReformatted (printDiff input source result) >> return r
+      when wasReformatted' (printDiff input source result) >> return r
     act' PrintSources = do
-      when wasReformatted (printSource $ reformattedSource result)
-      return (Reformat input (reformattedSource result) result)
-    act' PrintFilePaths = when wasReformatted (print input) >> return r
+      when wasReformatted' (printSource $ reformattedSource result)
+      return (Formatted input (reformattedSource result) result)
+    act' PrintFilePaths = when wasReformatted' (print input) >> return r
     act' WriteSources = do
-      when wasReformatted (writeSource input (reformattedSource result))
-      return (Reformat input (reformattedSource result) result)
-    wasReformatted = sourceChangedOrHasSuggestions source result
+      when wasReformatted' (writeSource input (reformattedSource result))
+      return (Formatted input (reformattedSource result) result)
+    wasReformatted' = wasReformatted source result
 
-sourceChangedOrHasSuggestions :: HaskellSource -> Reformatted -> Bool
-sourceChangedOrHasSuggestions source reformatted =
-  not (null (suggestions reformatted)) ||
-  source /= reformattedSource reformatted
-
-printDiff :: InputFile -> HaskellSource -> Reformatted -> IO ()
-printDiff (InputFilePath path) source reformatted = do
+printDiff :: SourceFile -> HaskellSource -> Reformatted -> IO ()
+printDiff (SourceFilePath path) source reformatted = do
   putStrLn (path ++ ":")
   mapM_ (putStr . show) (suggestions reformatted)
   putStr (showDiff source (reformattedSource reformatted))
-printDiff InputFromStdIn source reformatted = do
+printDiff SourceFromStdIn source reformatted = do
   mapM_ (putStr . show) (suggestions reformatted)
   putStr (showDiff source (reformattedSource reformatted))
 
 printSource :: HaskellSource -> IO ()
 printSource (HaskellSource _ source) = putStr source
 
-writeSource :: InputFile -> HaskellSource -> IO ()
-writeSource (InputFilePath path) (HaskellSource _ source) =
+writeSource :: SourceFile -> HaskellSource -> IO ()
+writeSource (SourceFilePath path) (HaskellSource _ source) =
   writeFile path source
-writeSource InputFromStdIn (HaskellSource _ source) = putStr source
+writeSource SourceFromStdIn (HaskellSource _ source) = putStr source

--- a/app/ExitCode.hs
+++ b/app/ExitCode.hs
@@ -1,0 +1,52 @@
+module ExitCode
+  ( exitCode
+  , helpDoc
+  , operationalFailureCode
+  ) where
+
+import Types
+
+import System.Exit
+import Text.PrettyPrint.ANSI.Leijen
+
+-- | Decide which exit code to use
+--
+-- Assume if we are printing diffs that we *are* being run in a CI and so
+-- should exit with failure if any format differences were found. Otherwise
+-- assume we are being run in a context where non-zero exit indicates
+-- failure of the tool to operate properly.
+exitCode :: Action -> Bool -> ExitCode
+exitCode action formattedCodeDiffers =
+  if formattedCodeDiffers && failOnDifferences
+    then ExitFailure formattedCodeDiffersFailureCode
+    else ExitSuccess
+  where
+    failOnDifferences = action == PrintDiffs
+
+helpDoc :: Doc
+helpDoc =
+  vsep
+    [ text "Exit Codes:"
+    , text "  0 = No error"
+    , text "  1 = Encountered I/O or other operational error"
+    , text "  2 = Failed to parse a source code file"
+    , text "  3 = Source code was parsed but cannot be formatted properly"
+    , text
+        "  4 = Formatted code differs from existing source (--print-diffs only)"
+    ]
+
+-- | Encountered I/O or other operational error
+operationalFailureCode :: Int
+operationalFailureCode = 1
+
+-- | Failed to parse a source code file
+parseFailureCode :: Int
+parseFailureCode = 2
+
+-- | Source code was parsed but cannot be formatted properly
+formattingFailureCode :: Int
+formattingFailureCode = 3
+
+-- | Formatted code differs from existing source code
+formattedCodeDiffersFailureCode :: Int
+formattedCodeDiffersFailureCode = 4

--- a/app/ExitCode.hs
+++ b/app/ExitCode.hs
@@ -39,14 +39,6 @@ helpDoc =
 operationalFailureCode :: Int
 operationalFailureCode = 1
 
--- | Failed to parse a source code file
-parseFailureCode :: Int
-parseFailureCode = 2
-
--- | Source code was parsed but cannot be formatted properly
-formattingFailureCode :: Int
-formattingFailureCode = 3
-
 -- | Formatted code differs from existing source code
 formattedCodeDiffersFailureCode :: Int
 formattedCodeDiffersFailureCode = 4

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,6 +5,7 @@ module Main
   ) where
 
 import Actions
+import ExitCode
 import Language.Haskell.Format
 import Language.Haskell.Format.Utilities
 import Language.Haskell.Source.Enumerator
@@ -23,23 +24,8 @@ import System.Exit
 main :: IO ()
 main = do
   options <- execParser Options.parser
-  changesToApply <- run options
-  exitWith $ exitCode options changesToApply
-
--- | Check if exit code should be non-zero if there are changes still needing to be applied
---
--- Assume if we are printing sources that we are not being run in a CI on
--- on the command line but actually as run as a tool inside neoformat or
--- similar context where non-zero exit indicates tool failure.
-exitCode :: Options -> Bool -> ExitCode
-exitCode options changesToApply =
-  if changesToApply && exitCodeShouldReflectChangesToApply options
-    then ExitFailure 1
-    else ExitSuccess
-  where
-    exitCodeShouldReflectChangesToApply :: Options -> Bool
-    exitCodeShouldReflectChangesToApply options =
-      optAction options /= PrintSources
+  formattedCodeDiffers <- run options
+  exitWith $ exitCode (optAction options) formattedCodeDiffers
 
 run :: Options -> IO Bool
 run options =

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -62,8 +62,10 @@ sourcesFromPath "-"  = yield StdinSource
 sourcesFromPath path = enumeratePath path .| mapC SourceFilePath
 
 readSource :: SourceFile -> IO SourceFileWithContents
-readSource s@(SourceFilePath path) = SourceFileWithContents s . HaskellSource path <$> readFile path
-readSource s@StdinSource = SourceFileWithContents s . HaskellSource "stdin" <$> getContents
+readSource s@(SourceFilePath path) =
+  SourceFileWithContents s . HaskellSource path <$> readFile path
+readSource s@StdinSource =
+  SourceFileWithContents s . HaskellSource "stdin" <$> getContents
 
 applyFormatter :: Formatter -> SourceFileWithContents -> FormatResult
 applyFormatter (Formatter format) (SourceFileWithContents file contents) =

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -26,16 +26,16 @@ main = do
   changesToApply <- run options
   exitWith $ exitCode options changesToApply
 
+-- | Check if exit code should be non-zero if there are changes still needing to be applied
+--
+-- Assume if we are printing sources that we are not being run in a CI on
+-- on the command line but actually as run as a tool inside neoformat or
+-- similar context where non-zero exit indicates tool failure.
 exitCode :: Options -> Bool -> ExitCode
 exitCode options changesToApply =
   if changesToApply && exitCodeShouldReflectChangesToApply options
     then ExitFailure 1
     else ExitSuccess
-  -- | Check if exit code should be non-zero if there are changes still needing to be applied
-  --
-  -- Assume if we are printing sources that we are not being run in a CI on
-  -- on the command line but actually as run as a tool inside neoformat or
-  -- similar context where non-zero exit indicates tool failure.
   where
     exitCodeShouldReflectChangesToApply :: Options -> Bool
     exitCodeShouldReflectChangesToApply options =

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -13,10 +13,6 @@ import Options
 import Types
 
 import Conduit
-import Control.Monad
-import Data.List
-import Data.Maybe
-import Data.Monoid
 import Options.Applicative.Extra          as OptApp
 import System.Directory
 import System.Exit
@@ -49,7 +45,7 @@ run options =
     handleFormatErrors = concatMapMC handleFormatError
     action = Actions.act options
     summarize =
-      anyC' (\(Formatted input source result) -> wasReformatted source result)
+      anyC' (\(Formatted _ source result) -> wasReformatted source result)
 
 sourcesFromPath :: FilePath -> Source IO SourceFile
 sourcesFromPath "-"  = yield StdinSource
@@ -62,9 +58,9 @@ readSource s@StdinSource =
   SourceFileWithContents s . HaskellSource "stdin" <$> getContents
 
 applyFormatter :: Formatter -> SourceFileWithContents -> FormatResult
-applyFormatter (Formatter format) (SourceFileWithContents file contents) =
-  case format contents of
-    Left error     -> Left (FormatError file error)
+applyFormatter (Formatter doFormat) (SourceFileWithContents file contents) =
+  case doFormat contents of
+    Left err       -> Left (FormatError file err)
     Right reformat -> Right (Formatted file contents reformat)
 
 handleFormatError :: FormatResult -> IO (Maybe Formatted)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -17,6 +17,7 @@ import Data.List
 import Data.Maybe
 import Data.Monoid
 import Options.Applicative.Extra          as OptApp
+import System.Directory
 import System.Exit
 
 main :: IO ()
@@ -47,8 +48,15 @@ run options =
   mapMC action .|
   summarize
   where
+    paths = do
+      let explicitPaths = optPaths options
+      if null explicitPaths
+        then do
+          currentPath <- getCurrentDirectory
+          return [currentPath]
+        else return explicitPaths
     sources :: Source IO SourceFile
-    sources = mapM_ sourcesFromPath (optPaths options) -- TODO Default to '.' if no sources given
+    sources = lift paths >>= mapM_ sourcesFromPath
     formatSource source = do
       formatter <- defaultFormatter
       return $ applyFormatter formatter source

--- a/app/Options.hs
+++ b/app/Options.hs
@@ -9,7 +9,6 @@ import qualified ExitCode
 import           Types
 
 import           Control.Applicative
-import           Data.List
 import           Data.Monoid
 import           Options.Applicative.Builder
 import           Options.Applicative.Common

--- a/app/Options.hs
+++ b/app/Options.hs
@@ -5,15 +5,16 @@ module Options
   , parser
   ) where
 
-import Types
+import qualified ExitCode
+import           Types
 
-import Control.Applicative
-import Data.List
-import Data.Monoid
-import Options.Applicative.Builder
-import Options.Applicative.Common
-import Options.Applicative.Extra
-import Text.PrettyPrint.ANSI.Leijen hiding ((<$>), (<>))
+import           Control.Applicative
+import           Data.List
+import           Data.Monoid
+import           Options.Applicative.Builder
+import           Options.Applicative.Common
+import           Options.Applicative.Extra
+import           Text.PrettyPrint.ANSI.Leijen as Leijen hiding ((<$>), (<>))
 
 data Options = Options
   { optPrintDiffs     :: Bool
@@ -39,47 +40,45 @@ optionParser =
     (long "print-diffs" <> short 'd' <>
      help "If a file's formatting is different, print a diff.") <*>
   switch
-    (long "print-sources" <> short 's' <>
+    (long "print-sources" <> short 's' <> hidden <>
      help "If a file's formatting is different, print its source.") <*>
   switch
-    (long "print-paths" <> short 'l' <>
+    (long "print-paths" <> short 'l' <> hidden <>
      help "If a file's formatting is different, print its path.") <*>
   switch
-    (long "write-sources" <> short 'w' <>
+    (long "write-sources" <> short 'w' <> hidden <>
      help "If a file's formatting is different, overwrite it.") <*>
   many pathOption
   where
-    pathOption = strArgument (metavar "PATH" <> pathOptionHelp)
+    pathOption = strArgument (metavar "FILE" <> pathOptionHelp)
     pathOptionHelp =
       helpDoc $
       Just $
-      paragraph "Explicit paths to process." <> hardline <>
+      text "Explicit paths to process." <> line <>
       unorderdedList
         " - "
-        [ paragraph "A single '-' will process standard input."
-        , paragraph "Files will be processed directly."
-        , paragraph
+        [ text "A single '-' will process standard input."
+        , text "Files will be processed directly."
+        , text
             "Directories will be recursively searched for source files to process."
-        , paragraph
+        , text
             ".cabal files will be parsed and all specified source directories and files processed."
-        , paragraph
+        , text
             "If no paths are given, the current directory will be searched for .cabal files to process, if none are found the current directory will be recursively searched for source files to process."
         ]
 
-paragraph :: String -> Doc
-paragraph = mconcat . intersperse softline . map text . words
-
 unorderdedList :: String -> [Doc] -> Doc
-unorderdedList prefix =
-  encloseSep (text prefix) mempty (text prefix) . map (hang 0)
+unorderdedList prefix = vsep . map ((text prefix <>)) . map align
 
 optionParserInfo :: ParserInfo Options
 optionParserInfo =
   info
     (helper <*> optionParser)
-    (fullDesc <> header "hfmt - format Haskell programs" <>
+    (fullDesc <> header "hfmt - Format Haskell programs" <>
      progDesc
-       "Operates on Haskell source files, reformatting them by applying suggestions from HLint, hindent, and stylish-haskell. Inspired by the gofmt utility.")
+       "Reformats Haskell source files by applying HLint, hindent, and stylish-haskell." <>
+     footerDoc (Just ExitCode.helpDoc) <>
+     failureCode ExitCode.operationalFailureCode)
 
 parser :: ParserInfo Options
 parser = optionParserInfo

--- a/app/Options.hs
+++ b/app/Options.hs
@@ -1,4 +1,4 @@
-module OptionsParser
+module Options
   ( Options
   , optAction
   , optPaths

--- a/app/Options.hs
+++ b/app/Options.hs
@@ -68,7 +68,7 @@ optionParser =
         ]
 
 unorderdedList :: String -> [Doc] -> Doc
-unorderdedList prefix = vsep . map ((text prefix <>)) . map align
+unorderdedList prefix = vsep . map ((text prefix <>) . align)
 
 optionParserInfo :: ParserInfo Options
 optionParserInfo =

--- a/app/Types.hs
+++ b/app/Types.hs
@@ -1,11 +1,12 @@
 module Types
   ( Action(..)
-  , InputFile(..)
-  , InputFileWithSource(..)
-  , ErrorString
-  , ReformatResult(..)
+  , FormatResult
+  , FormatError(..)
+  , Formatted(..)
   , HaskellSourceFilePath
   , HaskellSource(..)
+  , SourceFile(..)
+  , SourceFileWithContents(..)
   ) where
 
 import Language.Haskell.Format
@@ -16,24 +17,27 @@ data Action
   | PrintSources
   | PrintFilePaths
   | WriteSources
+  deriving (Eq)
 
-data InputFile
-  = InputFilePath HaskellSourceFilePath
-  | InputFromStdIn
+data SourceFile
+  = SourceFilePath HaskellSourceFilePath
+  | SourceFromStdIn
 
-instance Show InputFile where
-  show (InputFilePath path) = path
-  show InputFromStdIn       = "-"
+instance Show SourceFile where
+  show (SourceFilePath path) = path
+  show SourceFromStdIn       = "-"
 
-data InputFileWithSource =
-  InputFileWithSource InputFile
-                      HaskellSource
+data SourceFileWithContents =
+  SourceFileWithContents SourceFile
+                         HaskellSource
 
-type ErrorString = String
+type FormatResult = Either FormatError Formatted
 
-data ReformatResult
-  = InvalidReformat InputFile
-                    ErrorString
-  | Reformat InputFile
-             HaskellSource
-             Reformatted
+data FormatError =
+  FormatError SourceFile
+              String
+
+data Formatted =
+  Formatted SourceFile
+            HaskellSource
+            Reformatted

--- a/app/Types.hs
+++ b/app/Types.hs
@@ -3,14 +3,12 @@ module Types
   , FormatResult
   , FormatError(..)
   , Formatted(..)
-  , HaskellSourceFilePath
   , HaskellSource(..)
   , SourceFile(..)
   , SourceFileWithContents(..)
   ) where
 
 import Language.Haskell.Format
-import Language.Haskell.Source.Enumerator (HaskellSourceFilePath)
 
 data Action
   = PrintDiffs
@@ -20,12 +18,12 @@ data Action
   deriving (Eq)
 
 data SourceFile
-  = SourceFilePath HaskellSourceFilePath
-  | SourceFromStdIn
+  = SourceFilePath FilePath
+  | StdinSource
 
 instance Show SourceFile where
   show (SourceFilePath path) = path
-  show SourceFromStdIn       = "-"
+  show StdinSource           = "-"
 
 data SourceFileWithContents =
   SourceFileWithContents SourceFile

--- a/hfmt.cabal
+++ b/hfmt.cabal
@@ -51,6 +51,7 @@ executable hfmt
   Hs-Source-Dirs:    app
   Main-Is:           Main.hs
   Other-Modules:     Actions
+                   , ExitCode
                    , Options
                    , Types
   GHC-Options:       -Wall

--- a/hfmt.cabal
+++ b/hfmt.cabal
@@ -21,10 +21,10 @@ library
                      , Language.Haskell.Format.Utilities
                      , Language.Haskell.Source.Enumerator
   Other-Modules:     Language.Haskell.Format.Internal
-                     , Language.Haskell.Format.Definitions
                      , Language.Haskell.Format.HIndent
                      , Language.Haskell.Format.HLint
                      , Language.Haskell.Format.Stylish
+                     , Language.Haskell.Format.Types
                      , Path.Find
   GHC-Options:       -Wall
   Build-Depends:     base >= 4.8 && < 5

--- a/hfmt.cabal
+++ b/hfmt.cabal
@@ -30,6 +30,7 @@ library
   Build-Depends:     base >= 4.8 && < 5
                      , bytestring
                      , Cabal
+                     , conduit
                      , Diff
                      , directory
                      , exceptions
@@ -56,6 +57,7 @@ executable hfmt
                    , Types
   GHC-Options:       -Wall
   Build-Depends:     base == 4.*
+                   , conduit
                    , hfmt
                    , ansi-wl-pprint
                    , optparse-applicative

--- a/hfmt.cabal
+++ b/hfmt.cabal
@@ -53,11 +53,12 @@ executable hfmt
   Hs-Source-Dirs:    app
   Main-Is:           Main.hs
   Other-Modules:     Actions
-                   , OptionsParser
+                   , Options
                    , Types
   GHC-Options:       -Wall
   Build-Depends:     base == 4.*
                    , conduit
+                   , conduit-combinators
                    , hfmt
                    , ansi-wl-pprint
                    , optparse-applicative

--- a/hfmt.cabal
+++ b/hfmt.cabal
@@ -41,8 +41,6 @@ library
                      , HUnit
                      , path
                      , path-io
-                     , pipes
-                     , pipes-parse
                      , pretty
                      , stylish-haskell == 0.8.*
                      , text
@@ -62,7 +60,6 @@ executable hfmt
                    , hfmt
                    , ansi-wl-pprint
                    , optparse-applicative
-                   , pipes
 
 test-suite self-formatting-test
   Type:              exitcode-stdio-1.0

--- a/hfmt.cabal
+++ b/hfmt.cabal
@@ -56,7 +56,7 @@ executable hfmt
                    , Options
                    , Types
   GHC-Options:       -Wall
-  Build-Depends:     base == 4.*
+  Build-Depends:     base >= 4.8 && < 5
                    , conduit-combinators
                    , directory
                    , hfmt

--- a/hfmt.cabal
+++ b/hfmt.cabal
@@ -30,7 +30,7 @@ library
   Build-Depends:     base >= 4.8 && < 5
                      , bytestring
                      , Cabal
-                     , conduit
+                     , conduit-combinators
                      , Diff
                      , directory
                      , exceptions
@@ -57,7 +57,6 @@ executable hfmt
                    , Types
   GHC-Options:       -Wall
   Build-Depends:     base == 4.*
-                   , conduit
                    , conduit-combinators
                    , hfmt
                    , ansi-wl-pprint

--- a/hfmt.cabal
+++ b/hfmt.cabal
@@ -58,6 +58,7 @@ executable hfmt
   GHC-Options:       -Wall
   Build-Depends:     base == 4.*
                    , conduit-combinators
+                   , directory
                    , hfmt
                    , ansi-wl-pprint
                    , optparse-applicative

--- a/src/Language/Haskell/Format.hs
+++ b/src/Language/Haskell/Format.hs
@@ -12,10 +12,10 @@ module Language.Haskell.Format
   , Reformatted(..)
   ) where
 
-import           Language.Haskell.Format.Definitions
-import qualified Language.Haskell.Format.HIndent     as HIndent
-import qualified Language.Haskell.Format.HLint       as HLint
-import qualified Language.Haskell.Format.Stylish     as Stylish
+import qualified Language.Haskell.Format.HIndent as HIndent
+import qualified Language.Haskell.Format.HLint   as HLint
+import qualified Language.Haskell.Format.Stylish as Stylish
+import           Language.Haskell.Format.Types
 
 import           Control.Applicative
 

--- a/src/Language/Haskell/Format.hs
+++ b/src/Language/Haskell/Format.hs
@@ -17,8 +17,6 @@ import qualified Language.Haskell.Format.HLint   as HLint
 import qualified Language.Haskell.Format.Stylish as Stylish
 import           Language.Haskell.Format.Types
 
-import           Control.Applicative
-
 data Settings =
   Settings
 

--- a/src/Language/Haskell/Format/HIndent.hs
+++ b/src/Language/Haskell/Format/HIndent.hs
@@ -6,22 +6,22 @@ module Language.Haskell.Format.HIndent
 
 import           Control.Applicative
 import           Data.ByteString.Builder
-import           Data.ByteString.Lazy                as L
+import           Data.ByteString.Lazy             as L
 import           Data.Maybe                          ()
-import qualified Data.Text                           as Text
-import           Data.Text.Encoding                  as Encoding
-import           Data.Text.Lazy                      as TL
+import qualified Data.Text                        as Text
+import           Data.Text.Encoding               as Encoding
+import           Data.Text.Lazy                   as TL
 import           Data.Text.Lazy.Builder
-import qualified Data.Yaml                           as Y
+import qualified Data.Yaml                        as Y
 import           HIndent
 import           HIndent.Types
-import           Language.Haskell.Exts.Extension     (Extension)
+import           Language.Haskell.Exts.Extension  (Extension)
 import           Path
-import qualified Path.Find                           as Path
-import qualified Path.IO                             as Path
+import qualified Path.Find                        as Path
+import qualified Path.IO                          as Path
 
-import           Language.Haskell.Format.Definitions
 import           Language.Haskell.Format.Internal
+import           Language.Haskell.Format.Types
 
 data Settings =
   Settings Config

--- a/src/Language/Haskell/Format/HIndent.hs
+++ b/src/Language/Haskell/Format/HIndent.hs
@@ -4,14 +4,10 @@ module Language.Haskell.Format.HIndent
   , defaultFormatter
   ) where
 
-import           Control.Applicative
 import           Data.ByteString.Builder
 import           Data.ByteString.Lazy             as L
-import           Data.Maybe                          ()
 import qualified Data.Text                        as Text
 import           Data.Text.Encoding               as Encoding
-import           Data.Text.Lazy                   as TL
-import           Data.Text.Lazy.Builder
 import qualified Data.Yaml                        as Y
 import           HIndent
 import           HIndent.Types

--- a/src/Language/Haskell/Format/HLint.hs
+++ b/src/Language/Haskell/Format/HLint.hs
@@ -6,7 +6,6 @@ module Language.Haskell.Format.HLint
 import           Language.Haskell.Format.Internal
 import           Language.Haskell.Format.Types
 
-import           Control.Applicative
 import           Language.Haskell.HLint3          (Classify, Hint,
                                                    ParseError (..), ParseFlags,
                                                    applyHints, parseModuleEx)

--- a/src/Language/Haskell/Format/HLint.hs
+++ b/src/Language/Haskell/Format/HLint.hs
@@ -3,16 +3,15 @@ module Language.Haskell.Format.HLint
   , suggester
   ) where
 
-import           Language.Haskell.Format.Definitions
 import           Language.Haskell.Format.Internal
+import           Language.Haskell.Format.Types
 
 import           Control.Applicative
-import           Language.Haskell.HLint3             (Classify, Hint,
-                                                      ParseError (..),
-                                                      ParseFlags, applyHints,
-                                                      parseModuleEx)
-import qualified Language.Haskell.HLint3             as HLint3
-import           System.IO.Unsafe                    (unsafePerformIO)
+import           Language.Haskell.HLint3          (Classify, Hint,
+                                                   ParseError (..), ParseFlags,
+                                                   applyHints, parseModuleEx)
+import qualified Language.Haskell.HLint3          as HLint3
+import           System.IO.Unsafe                 (unsafePerformIO)
 
 suggester :: (ParseFlags, [Classify], Hint) -> Formatter
 suggester = mkSuggester . hlint

--- a/src/Language/Haskell/Format/Internal.hs
+++ b/src/Language/Haskell/Format/Internal.hs
@@ -5,8 +5,6 @@ module Language.Haskell.Format.Internal
 
 import Language.Haskell.Format.Types
 
-import Control.Applicative
-
 mkFormatter :: (HaskellSource -> Either String HaskellSource) -> Formatter
 mkFormatter f = Formatter (fmap (\source -> Reformatted source []) . f)
 

--- a/src/Language/Haskell/Format/Internal.hs
+++ b/src/Language/Haskell/Format/Internal.hs
@@ -3,7 +3,7 @@ module Language.Haskell.Format.Internal
   , mkSuggester
   ) where
 
-import Language.Haskell.Format.Definitions
+import Language.Haskell.Format.Types
 
 import Control.Applicative
 

--- a/src/Language/Haskell/Format/Stylish.hs
+++ b/src/Language/Haskell/Format/Stylish.hs
@@ -4,10 +4,10 @@ module Language.Haskell.Format.Stylish
   ) where
 
 import Control.Applicative
-import Language.Haskell.Stylish            as Stylish
+import Language.Haskell.Stylish         as Stylish
 
-import Language.Haskell.Format.Definitions
 import Language.Haskell.Format.Internal
+import Language.Haskell.Format.Types
 
 newtype Settings =
   Settings Stylish.Config

--- a/src/Language/Haskell/Format/Stylish.hs
+++ b/src/Language/Haskell/Format/Stylish.hs
@@ -3,7 +3,6 @@ module Language.Haskell.Format.Stylish
   , formatter
   ) where
 
-import Control.Applicative
 import Language.Haskell.Stylish         as Stylish
 
 import Language.Haskell.Format.Internal

--- a/src/Language/Haskell/Format/Types.hs
+++ b/src/Language/Haskell/Format/Types.hs
@@ -7,7 +7,7 @@ module Language.Haskell.Format.Types
 
 import Control.Applicative
 import Control.Monad
-import Data.Monoid
+import Data.Monoid         ((<>))
 
 type ErrorString = String
 

--- a/src/Language/Haskell/Format/Types.hs
+++ b/src/Language/Haskell/Format/Types.hs
@@ -1,4 +1,4 @@
-module Language.Haskell.Format.Definitions
+module Language.Haskell.Format.Types
   ( HaskellSource(..)
   , Reformatted(..)
   , Formatter(..)

--- a/src/Language/Haskell/Format/Types.hs
+++ b/src/Language/Haskell/Format/Types.hs
@@ -5,9 +5,8 @@ module Language.Haskell.Format.Types
   , Suggestion(..)
   ) where
 
-import Control.Applicative
 import Control.Monad
-import Data.Monoid         ((<>))
+import Data.Monoid   ((<>))
 
 type ErrorString = String
 

--- a/src/Language/Haskell/Format/Utilities.hs
+++ b/src/Language/Haskell/Format/Utilities.hs
@@ -8,7 +8,7 @@ module Language.Haskell.Format.Utilities
 import           System.IO.Unsafe
 
 import           Language.Haskell.Format
-import           Language.Haskell.Format.Definitions
+import           Language.Haskell.Format.Types
 import           Language.Haskell.Source.Enumerator
 
 import           Control.Applicative
@@ -21,7 +21,7 @@ import           Data.Maybe
 import           Data.Monoid
 import           Pipes
 import           Pipes.Parse
-import qualified Pipes.Prelude                       as P
+import qualified Pipes.Prelude                      as P
 import           Test.HUnit
 import           Text.PrettyPrint
 

--- a/src/Language/Haskell/Format/Utilities.hs
+++ b/src/Language/Haskell/Format/Utilities.hs
@@ -8,17 +8,13 @@ module Language.Haskell.Format.Utilities
 import System.IO.Unsafe
 
 import Language.Haskell.Format
-import Language.Haskell.Format.Types
 import Language.Haskell.Source.Enumerator
 
 import Conduit
 import Control.Monad
-import Data.Algorithm.Diff
 import Data.Algorithm.DiffContext
-import Data.Algorithm.DiffOutput
 import Data.List
 import Data.Maybe
-import Data.Monoid
 import Test.HUnit
 import Text.PrettyPrint
 
@@ -67,7 +63,7 @@ assertCheckResult result =
       whenMaybe
         (sourceChanged source reformatted)
         (showDiff source (reformattedSource reformatted))
-    showSuggestions source reformatted =
+    showSuggestions _ reformatted =
       whenMaybe
         (hasSuggestions reformatted)
         (concatMap show (suggestions reformatted))
@@ -90,9 +86,9 @@ readSourceFile :: FilePath -> IO HaskellSource
 readSourceFile filepath = HaskellSource filepath <$> readFile filepath
 
 checkFormatting :: Formatter -> HaskellSource -> CheckResult
-checkFormatting (Formatter format) source =
-  case format source of
-    Left error        -> InvalidCheckResult source error
+checkFormatting (Formatter doFormat) source =
+  case doFormat source of
+    Left err          -> InvalidCheckResult source err
     Right reformatted -> CheckResult source reformatted
 
 defaultFormatter :: IO Formatter

--- a/src/Language/Haskell/Format/Utilities.hs
+++ b/src/Language/Haskell/Format/Utilities.hs
@@ -40,7 +40,8 @@ hunitTest filepath = TestLabel filepath . unsafePerformIO . testPath $ filepath
 testPath :: FilePath -> IO Test
 testPath filepath = do
   formatter <- defaultFormatter
-  TestList <$> runConduit (check formatter filepath .| mapC makeTestCase .| sinkList)
+  TestList <$>
+    runConduit (check formatter filepath .| mapC makeTestCase .| sinkList)
 
 makeTestCase :: CheckResult -> Test
 makeTestCase result =
@@ -82,7 +83,8 @@ showDiff (HaskellSource _ a) (HaskellSource _ b) = render (toDoc diff)
 
 check :: Formatter -> FilePath -> Source IO CheckResult
 check formatter filepath =
-  enumeratePath filepath .| mapMC readSourceFile .| mapC (checkFormatting formatter)
+  enumeratePath filepath .| mapMC readSourceFile .|
+  mapC (checkFormatting formatter)
 
 readSourceFile :: FilePath -> IO HaskellSource
 readSourceFile filepath = HaskellSource filepath <$> readFile filepath

--- a/src/Language/Haskell/Format/Utilities.hs
+++ b/src/Language/Haskell/Format/Utilities.hs
@@ -11,7 +11,6 @@ import           Language.Haskell.Format
 import           Language.Haskell.Format.Types
 import           Language.Haskell.Source.Enumerator
 
-import           Control.Applicative
 import           Control.Monad
 import           Data.Algorithm.Diff
 import           Data.Algorithm.DiffContext

--- a/src/Language/Haskell/Source/Enumerator.hs
+++ b/src/Language/Haskell/Source/Enumerator.hs
@@ -29,7 +29,7 @@ enumPath path = do
 enumPackage :: FilePath -> Source IO FilePath
 enumPackage cabalFile = readPackage cabalFile >>= expandPaths
   where
-    readPackage = lift . readPackageDescription Verbosity.silent
+    readPackage = lift . readGenericPackageDescription Verbosity.silent
     expandPaths = mapM_ (enumPath . mkFull) . sourcePaths
     packageDir = dropFileName cabalFile
     mkFull = (packageDir </>)

--- a/src/Language/Haskell/Source/Enumerator.hs
+++ b/src/Language/Haskell/Source/Enumerator.hs
@@ -3,7 +3,6 @@ module Language.Haskell.Source.Enumerator
   , HaskellSourceFilePath
   ) where
 
-import           Control.Applicative
 import           Control.Monad
 import           Data.List
 import           Distribution.PackageDescription

--- a/src/Language/Haskell/Source/Enumerator.hs
+++ b/src/Language/Haskell/Source/Enumerator.hs
@@ -19,9 +19,11 @@ enumPath :: FilePath -> Source IO FilePath
 enumPath path = do
   isDirectory <- lift $ doesDirectoryExist path
   case isDirectory of
-    True  -> enumDirectory path
-    False | hasCabalExtension path -> enumPackage path
-    False | hasHaskellExtension path -> yield path
+    True -> enumDirectory path
+    False
+      | hasCabalExtension path -> enumPackage path
+    False
+      | hasHaskellExtension path -> yield path
     False -> return ()
 
 enumPackage :: FilePath -> Source IO FilePath
@@ -72,4 +74,5 @@ sourcePaths pkg = nub $ concatMap ($ pkg) pathExtractors
 
 (<&&>) :: Applicative f => f Bool -> f Bool -> f Bool
 (<&&>) = liftA2 (&&)
+
 infixr 3 <&&> -- same as (&&)

--- a/src/Language/Haskell/Source/Enumerator.hs
+++ b/src/Language/Haskell/Source/Enumerator.hs
@@ -1,9 +1,11 @@
 module Language.Haskell.Source.Enumerator
   ( enumeratePath
+  , enumeratePathC
   , HaskellSourceFilePath
   ) where
 
 import           Control.Monad
+import           Data.Conduit                          (Source)
 import           Data.List
 import           Distribution.PackageDescription
 import           Distribution.PackageDescription.Parse
@@ -14,6 +16,9 @@ import           System.Directory
 import           System.FilePath
 
 type HaskellSourceFilePath = FilePath
+
+enumeratePathC :: FilePath -> Source IO FilePath
+enumeratePathC = undefined
 
 enumeratePath :: FilePath -> Producer HaskellSourceFilePath IO ()
 enumeratePath path = filePath path >-> P.map normalise

--- a/src/Language/Haskell/Source/Enumerator.hs
+++ b/src/Language/Haskell/Source/Enumerator.hs
@@ -1,77 +1,47 @@
 module Language.Haskell.Source.Enumerator
   ( enumeratePath
-  , enumeratePathC
-  , HaskellSourceFilePath
   ) where
 
+import           Conduit
+import           Control.Applicative
 import           Control.Monad
-import           Data.Conduit                          (Source)
 import           Data.List
 import           Distribution.PackageDescription
 import           Distribution.PackageDescription.Parse
 import qualified Distribution.Verbosity                as Verbosity
-import           Pipes
-import qualified Pipes.Prelude                         as P
 import           System.Directory
 import           System.FilePath
 
-type HaskellSourceFilePath = FilePath
+enumeratePath :: FilePath -> Source IO FilePath
+enumeratePath path = enumPath path .| mapC normalise
 
-enumeratePathC :: FilePath -> Source IO FilePath
-enumeratePathC = undefined
+enumPath :: FilePath -> Source IO FilePath
+enumPath path = do
+  isDirectory <- lift $ doesDirectoryExist path
+  case isDirectory of
+    True  -> enumDirectory path
+    False | hasCabalExtension path -> enumPackage path
+    False | hasHaskellExtension path -> yield path
+    False -> return ()
 
-enumeratePath :: FilePath -> Producer HaskellSourceFilePath IO ()
-enumeratePath path = filePath path >-> P.map normalise
-
-filePath :: FilePath -> Producer HaskellSourceFilePath IO ()
-filePath path = do
-  isCabal <- lift $ isCabalFile path
-  if isCabal
-    then package' path
-    else directoryOrFile path
-
-simpleFilePath :: FilePath -> Producer HaskellSourceFilePath IO ()
-simpleFilePath path = do
-  isHaskellSource <- lift $ isHaskellSourceFile path
-  when isHaskellSource $ yield path
-
-simpleDirectory :: FilePath -> Producer HaskellSourceFilePath IO ()
-simpleDirectory path = do
-  contents <- lift $ getDirectoryContentsFullPaths path
-  mapM_ simpleFileOrDirectory contents
-
-simpleFileOrDirectory :: FilePath -> Producer HaskellSourceFilePath IO ()
-simpleFileOrDirectory filepath = do
-  dir <- lift $ doesDirectoryExist filepath
-  if dir
-    then simpleDirectory filepath
-    else simpleFilePath filepath
-
-package' :: FilePath -> Producer HaskellSourceFilePath IO ()
-package' path = readPackage path >>= expandPaths
+enumPackage :: FilePath -> Source IO FilePath
+enumPackage cabalFile = readPackage cabalFile >>= expandPaths
   where
     readPackage = lift . readPackageDescription Verbosity.silent
-    expandPaths = mapM_ (simpleFileOrDirectory . mkFull) . sourcePaths
-    dir = dropFileName path
-    mkFull = (dir </>)
+    expandPaths = mapM_ (enumPath . mkFull) . sourcePaths
+    packageDir = dropFileName cabalFile
+    mkFull = (packageDir </>)
 
-directory :: FilePath -> Producer HaskellSourceFilePath IO ()
-directory path = do
-  contents <- lift $ getDirectoryContentsFullPaths path
+enumDirectory :: FilePath -> Source IO FilePath
+enumDirectory path = do
+  contents <- lift $ getDirectoryContentFullPaths path
   cabalFiles <- lift $ filterM isCabalFile contents
   if null cabalFiles
-    then mapM_ directoryOrFile contents
-    else mapM_ package' cabalFiles
+    then mapM_ enumPath contents
+    else mapM_ enumPackage cabalFiles
 
-directoryOrFile :: FilePath -> Producer HaskellSourceFilePath IO ()
-directoryOrFile path = do
-  isFile <- lift $ doesFileExist path
-  if isFile
-    then simpleFilePath path
-    else directory path
-
-getDirectoryContentsFullPaths :: FilePath -> IO [FilePath]
-getDirectoryContentsFullPaths path =
+getDirectoryContentFullPaths :: FilePath -> IO [FilePath]
+getDirectoryContentFullPaths path =
   mkFull . notHidden . notMeta <$> getDirectoryContents path
   where
     mkFull = map (path </>)
@@ -79,16 +49,13 @@ getDirectoryContentsFullPaths path =
     notMeta = (\\ [".", ".."])
 
 isCabalFile :: FilePath -> IO Bool
-isCabalFile path = (hasCabalExtension &&) <$> isFile
-  where
-    isFile = doesFileExist path
-    hasCabalExtension = ".cabal" `isSuffixOf` path
+isCabalFile path = return (hasCabalExtension path) <&&> doesFileExist path
 
-isHaskellSourceFile :: FilePath -> IO Bool
-isHaskellSourceFile path = (hasHaskellExtension &&) <$> isFile
-  where
-    isFile = doesFileExist path
-    hasHaskellExtension = ".hs" `isSuffixOf` path || ".lhs" `isSuffixOf` path
+hasCabalExtension :: FilePath -> Bool
+hasCabalExtension path = ".cabal" `isSuffixOf` path
+
+hasHaskellExtension :: FilePath -> Bool
+hasHaskellExtension path = ".hs" `isSuffixOf` path || ".lhs" `isSuffixOf` path
 
 sourcePaths :: GenericPackageDescription -> [FilePath]
 sourcePaths pkg = nub $ concatMap ($ pkg) pathExtractors
@@ -102,3 +69,7 @@ sourcePaths pkg = nub $ concatMap ($ pkg) pathExtractors
       , concatMap (hsSourceDirs . benchmarkBuildInfo . condTreeData . snd) .
         condBenchmarks
       ]
+
+(<&&>) :: Applicative f => f Bool -> f Bool -> f Bool
+(<&&>) = liftA2 (&&)
+infixr 3 <&&> -- same as (&&)

--- a/src/Language/Haskell/Source/Enumerator.hs
+++ b/src/Language/Haskell/Source/Enumerator.hs
@@ -29,7 +29,7 @@ enumPath path = do
 enumPackage :: FilePath -> Source IO FilePath
 enumPackage cabalFile = readPackage cabalFile >>= expandPaths
   where
-    readPackage = lift . readGenericPackageDescription Verbosity.silent
+    readPackage = lift . readPackageDescription Verbosity.silent
     expandPaths = mapM_ (enumPath . mkFull) . sourcePaths
     packageDir = dropFileName cabalFile
     mkFull = (packageDir </>)

--- a/src/Path/Find.hs
+++ b/src/Path/Find.hs
@@ -6,14 +6,11 @@ module Path.Find
   ( findFileUp
   ) where
 
-import Control.Exception      (evaluate)
-import Control.Monad
 import Control.Monad.Catch
 import Control.Monad.IO.Class
 import Data.List
 import Path
 import Path.IO
-import System.IO.Error        (isPermissionError)
 
 -- | Find the location of a file matching the given predicate.
 findFileUp ::
@@ -23,15 +20,6 @@ findFileUp ::
   -> Maybe (Path Abs Dir) -- ^ Do not ascend above this directory.
   -> m (Maybe (Path Abs File)) -- ^ Absolute file path.
 findFileUp = findPathUp snd
-
--- | Find the location of a directory matching the given predicate.
-findDirUp ::
-     (MonadIO m, MonadThrow m)
-  => Path Abs Dir -- ^ Start here.
-  -> (Path Abs Dir -> Bool) -- ^ Predicate to match the directory.
-  -> Maybe (Path Abs Dir) -- ^ Do not ascend above this directory.
-  -> m (Maybe (Path Abs Dir)) -- ^ Absolute directory path.
-findDirUp = findPathUp fst
 
 -- | Find the location of a path matching the given predicate.
 findPathUp ::

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,4 +2,4 @@ flags: {}
 packages:
 - '.'
 extra-deps: []
-resolver: lts-10.2
+resolver: lts-10.3


### PR DESCRIPTION
- Follow discussion in #19 and switch to exit code semantics similar to rustfmt
- Use Conduit library instead of pipes
- Various cleanup, formatting and fixing compile warnings

Fixes #19