### PR TITLE
Fail with non-zero error code when the code contains a syntax error

### DIFF
--- a/app/Types.hs
+++ b/app/Types.hs
@@ -35,6 +35,10 @@ data FormatError =
   FormatError SourceFile
               String
 
+instance Show FormatError where
+  show (FormatError input errorString) =
+    "Error reformatting " ++ show input ++ ": " ++ errorString
+
 data Formatted =
   Formatted SourceFile
             HaskellSource


### PR DESCRIPTION
It is very helpful for editor extensions. Otherwise it's not possible to
get whether the command succeeded or not.
This is a vs code extension which is based on these changes https://github.com/sergey-kintsel/hfmt-vscode