### PR TITLE
Fix failing hindent on `using` infix operator

### DIFF
--- a/src/Language/Haskell/Format/HIndent.hs
+++ b/src/Language/Haskell/Format/HIndent.hs
@@ -29,7 +29,7 @@ defaultFormatter = formatter <$> autoSettings
 autoSettings :: IO Settings
 autoSettings = do
   config <- getConfig
-  return (Settings config Nothing)
+  return $ Settings config $ Just defaultExtensions
 
 -- | Read config from a config file, or return 'defaultConfig'.
 getConfig :: IO Config


### PR DESCRIPTION
I am trying to format this code:
```haskell
x = a `using` b
```

and I get this:
```
Error reformatting example.hs: <interactive>:1:12: Parse error: using
```

The thing is that if I change `using` to `usingA` it works just fine.
I debugged it a bit and got to this line:
https://github.com/danstiner/hfmt/blob/master/src/Language/Haskell/Format.hs#L36
I have experimented with the list of formatters and it appears that indeed hindent fails.
The funny thing is that hindent itself doesn't break if I run it alone.

The easiest solution is to follow the way hindent itself uses `reformat` function
https://github.com/commercialhaskell/hindent/blob/889e1655c6eb170e0d30c3c1173f7fba87041736/src/main/Test.hs#L32