### PR TITLE
Avoid sequencing entire list into memory

### DIFF
--- a/app/ExitCode.hs
+++ b/app/ExitCode.hs
@@ -16,13 +16,12 @@ import Text.PrettyPrint.ANSI.Leijen
 -- should exit with failure if any format differences were found. Otherwise
 -- assume we are being run in a context where non-zero exit indicates
 -- failure of the tool to operate properly.
-exitCode :: Action -> Bool -> ExitCode
-exitCode action hadDifferences =
-  if hadDifferences && failOnDifferences
-    then ExitFailure formattedCodeDiffersFailureCode
-    else ExitSuccess
-  where
-    failOnDifferences = action == PrintDiffs
+exitCode :: Action -> RunResult -> ExitCode
+exitCode _ NoDifferences = ExitSuccess
+exitCode PrintDiffs HadDifferences = ExitFailure formattedCodeDiffersFailureCode
+exitCode _ HadDifferences = ExitSuccess
+exitCode _ SourceParseFailure = ExitFailure sourceParseFailureCode
+exitCode _ OperationalFailure = ExitFailure operationalFailureCode
 
 helpDoc :: Doc
 helpDoc =

--- a/app/ExitCode.hs
+++ b/app/ExitCode.hs
@@ -17,8 +17,8 @@ import Text.PrettyPrint.ANSI.Leijen
 -- assume we are being run in a context where non-zero exit indicates
 -- failure of the tool to operate properly.
 exitCode :: Action -> Bool -> ExitCode
-exitCode action formattedCodeDiffers =
-  if formattedCodeDiffers && failOnDifferences
+exitCode action hadDifferences =
+  if hadDifferences && failOnDifferences
     then ExitFailure formattedCodeDiffersFailureCode
     else ExitSuccess
   where

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -13,7 +13,6 @@ import Options
 import Types
 
 import Conduit
-import Data.Bitraversable
 import Options.Applicative.Extra          as OptApp
 import System.Directory
 import System.Exit
@@ -35,7 +34,7 @@ run opt =
       formatter <- defaultFormatter
       return $ applyFormatter formatter source
     doAction :: FormatResult -> IO FormatResult
-    doAction = bitraverse return (Actions.act opt)
+    doAction = bimapM return (Actions.act opt)
     toRunResult :: FormatResult -> IO RunResult
     toRunResult (Left err) = do
       hPrint stderr (show err)
@@ -71,3 +70,7 @@ applyFormatter (Formatter doFormat) (SourceFileWithContents file contents) =
   case doFormat contents of
     Left err       -> Left (FormatError file err)
     Right reformat -> Right (Formatted file contents reformat)
+
+bimapM :: Monad m => (a -> m c) -> (b -> m d) -> Either a b -> m (Either c d)
+bimapM f _ (Left a)  = Left <$> f a
+bimapM _ g (Right b) = Right <$> g b

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,18 +4,19 @@ module Main
   ( main
   ) where
 
-import Actions
-import ExitCode
-import Language.Haskell.Format
-import Language.Haskell.Format.Utilities
-import Language.Haskell.Source.Enumerator
-import Options
-import Types
+import           Actions
+import           ExitCode
+import           Language.Haskell.Format
+import           Language.Haskell.Format.Utilities
+import           Language.Haskell.Source.Enumerator
+import           Options
+import           Types
 
-import Conduit
-import Options.Applicative.Extra          as OptApp
-import System.Directory
-import System.Exit
+import           Conduit
+import qualified Data.Conduit.Combinators           as C
+import           Options.Applicative.Extra          as OptApp
+import           System.Directory
+import           System.Exit
 
 main :: IO ()
 main = do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -24,11 +24,11 @@ main = do
   case changes of
     Left err -> print err >> exitWith (ExitFailure sourceParseFailureCode)
     Right changes' -> do
-      formattedCodeDiffers <-
+      hadDifferences <-
         runConduit $
         yieldMany changes' .| mapMC (Actions.act options) .|
         anyC' (\(Formatted _ source result) -> wasReformatted source result)
-      exitWith $ exitCode (optAction options) formattedCodeDiffers
+      exitWith $ exitCode (optAction options) hadDifferences
 
 run :: Options -> IO (Either FormatError [Formatted])
 run options = do

--- a/app/Types.hs
+++ b/app/Types.hs
@@ -4,6 +4,7 @@ module Types
   , FormatError(..)
   , Formatted(..)
   , HaskellSource(..)
+  , RunResult(..)
   , SourceFile(..)
   , SourceFileWithContents(..)
   ) where
@@ -43,3 +44,17 @@ data Formatted =
   Formatted SourceFile
             HaskellSource
             Reformatted
+
+data RunResult
+  = OperationalFailure
+  | SourceParseFailure
+  | HadDifferences
+  | NoDifferences
+
+instance Monoid RunResult where
+  mempty = NoDifferences
+  x `mappend` NoDifferences = x
+  NoDifferences `mappend` x = x
+  OperationalFailure `mappend` _ = OperationalFailure
+  SourceParseFailure `mappend` _ = SourceParseFailure
+  HadDifferences `mappend` _ = HadDifferences


### PR DESCRIPTION
Fixing a regression where usage of `sequence` and `sourceList` would load all files into memory and not print results until the very end.

Fixes #29