### PR TITLE
Upgrade stylish-haskell to 0.11.x

### DIFF
--- a/hfmt.cabal
+++ b/hfmt.cabal
@@ -1,8 +1,10 @@
--- This file has been generated from package.yaml by hpack version 0.28.2.
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.33.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 912a3ad90fffd1b307d8fb1ad79185bfee0a9c0745522b0b9ed611cdd6fddbed
+-- hash: 01e8f8e707b78d3f39583670cae3dcb5ebb9a547e2c4339df12335f49d71598f
 
 name:           hfmt
 version:        0.2.3.1
@@ -16,9 +18,8 @@ author:         Daniel Stiner
 maintainer:     Daniel Stiner <daniel.stiner@gmail.com>
 license:        MIT
 license-file:   LICENSE
-tested-with:    GHC ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.3
+tested-with:    GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.2, GHC == 8.5
 build-type:     Simple
-cabal-version:  >= 1.10
 extra-source-files:
     .stylish-haskell.yaml
     LICENSE
@@ -62,7 +63,7 @@ library
     , path
     , path-io
     , pretty
-    , stylish-haskell ==0.9.*
+    , stylish-haskell ==0.11.*
     , text
     , transformers
     , yaml
@@ -99,7 +100,7 @@ executable hfmt
     , path
     , path-io
     , pretty
-    , stylish-haskell ==0.9.*
+    , stylish-haskell ==0.11.*
     , text
     , transformers
     , yaml
@@ -131,7 +132,7 @@ test-suite pure
     , path
     , path-io
     , pretty
-    , stylish-haskell ==0.9.*
+    , stylish-haskell ==0.11.*
     , test-framework
     , test-framework-hunit
     , text
@@ -165,7 +166,7 @@ test-suite self-formatting-test
     , path
     , path-io
     , pretty
-    , stylish-haskell ==0.9.*
+    , stylish-haskell ==0.11.*
     , test-framework
     , test-framework-hunit
     , text

--- a/package.yaml
+++ b/package.yaml
@@ -36,7 +36,7 @@ dependencies:
   - path
   - path-io
   - pretty
-  - stylish-haskell == 0.9.*
+  - stylish-haskell == 0.11.*
   - text
   - transformers
   - yaml

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,9 @@
 resolver: lts-14.6
 flags: {}
 packages:
-- '.'
+  - '.'
 extra-deps:
   - hindent-5.3.1
-  - stylish-haskell-0.9.2.2
+  - stylish-haskell-0.11.0.0
+  - HsYAML-0.2.1.0
+  - HsYAML-aeson-0.2.0.0

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -12,12 +12,26 @@ packages:
   original:
     hackage: hindent-5.3.1
 - completed:
-    hackage: stylish-haskell-0.9.2.2@sha256:7852ea649b83f899888fdc2559d25495d0959d832cb9ca9da53bae78df66dc0e,4581
+    hackage: stylish-haskell-0.11.0.0@sha256:1cf24f35b40557fc1784622e64e6290b7a1b1e410edd090bf379ee09df2cdc29,5369
     pantry-tree:
-      size: 2604
-      sha256: 5a3601e7630287e7e72d978dc5060395546165c9dbc079b77899e8f0e75d0bea
+      size: 3118
+      sha256: c58f40b59b1faecd136e79f0ff553af3dc4720043f86fe4cccb65ef1fb6665cc
   original:
-    hackage: stylish-haskell-0.9.2.2
+    hackage: stylish-haskell-0.11.0.0
+- completed:
+    hackage: HsYAML-0.2.1.0@sha256:6e63cbc919543c5a837040f063e96fe0a4e43bef8ab3c057cef8f122396fdc2d,5469
+    pantry-tree:
+      size: 1340
+      sha256: 77d9299977dfbc7836cbbcb51fe890bb70d485d9dd89a3bbe54822635faa8108
+  original:
+    hackage: HsYAML-0.2.1.0
+- completed:
+    hackage: HsYAML-aeson-0.2.0.0@sha256:6f9c10b46162fbd1562d89da94b46f3b7e8b5731a71fdb73438a2a251997a490,1853
+    pantry-tree:
+      size: 234
+      sha256: db01d1a92edd78336e0d4a608f0a8153cb8f7612fc8ae9cd45e9014c941d6db9
+  original:
+    hackage: HsYAML-aeson-0.2.0.0
 snapshots:
 - completed:
     size: 524127


### PR DESCRIPTION
I wanted this for my own purposes but figured it would be worth upstreaming. Feel free to close if you're not interested.

All the tests pass, and formatting my codebases all seems fine.

Signed-off-by: Cameron Diver <cameron.diver94@gmail.com>